### PR TITLE
Add import paths from lodash 3 for backwards compatibility

### DIFF
--- a/addon/array/chunk.js
+++ b/addon/array/chunk.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/chunk'

--- a/addon/array/compact.js
+++ b/addon/array/compact.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/compact'

--- a/addon/array/difference.js
+++ b/addon/array/difference.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/difference'

--- a/addon/array/drop.js
+++ b/addon/array/drop.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/drop'

--- a/addon/array/dropRight.js
+++ b/addon/array/dropRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/dropRight'

--- a/addon/array/dropWhile.js
+++ b/addon/array/dropWhile.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/dropWhile'

--- a/addon/array/fill.js
+++ b/addon/array/fill.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/fill'

--- a/addon/array/fillIndex.js
+++ b/addon/array/fillIndex.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/fillIndex'

--- a/addon/array/findLastIndex.js
+++ b/addon/array/findLastIndex.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/findLastIndex'

--- a/addon/array/first.js
+++ b/addon/array/first.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/first'

--- a/addon/array/flatten.js
+++ b/addon/array/flatten.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/flatten'

--- a/addon/array/flattenDeep.js
+++ b/addon/array/flattenDeep.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/flattenDeep'

--- a/addon/array/head.js
+++ b/addon/array/head.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/head'

--- a/addon/array/indexOf.js
+++ b/addon/array/indexOf.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/indexOf'

--- a/addon/array/initial.js
+++ b/addon/array/initial.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/initial'

--- a/addon/array/intersection.js
+++ b/addon/array/intersection.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/intersection'

--- a/addon/array/last.js
+++ b/addon/array/last.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/last'

--- a/addon/array/lastIndexOf.js
+++ b/addon/array/lastIndexOf.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/lastIndexOf'

--- a/addon/array/object.js
+++ b/addon/array/object.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/object'

--- a/addon/array/pull.js
+++ b/addon/array/pull.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/pull'

--- a/addon/array/pullAt.js
+++ b/addon/array/pullAt.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/pullAt'

--- a/addon/array/remove.js
+++ b/addon/array/remove.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/remove'

--- a/addon/array/rest.js
+++ b/addon/array/rest.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/tail'

--- a/addon/array/slice.js
+++ b/addon/array/slice.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/slice'

--- a/addon/array/sortedIndex.js
+++ b/addon/array/sortedIndex.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sortedIndex'

--- a/addon/array/sortedLastIndex.js
+++ b/addon/array/sortedLastIndex.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sortedLastIndex'

--- a/addon/array/tail.js
+++ b/addon/array/tail.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/tail'

--- a/addon/array/take.js
+++ b/addon/array/take.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/take'

--- a/addon/array/takeRight.js
+++ b/addon/array/takeRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/takeRight'

--- a/addon/array/takeRightWhile.js
+++ b/addon/array/takeRightWhile.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/takeRightWhile'

--- a/addon/array/takeWhile.js
+++ b/addon/array/takeWhile.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/takeWhile'

--- a/addon/array/union.js
+++ b/addon/array/union.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/union'

--- a/addon/array/uniq.js
+++ b/addon/array/uniq.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/uniq'

--- a/addon/array/unique.js
+++ b/addon/array/unique.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/uniq'

--- a/addon/array/unzip.js
+++ b/addon/array/unzip.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/unzip'

--- a/addon/array/unzipWith.js
+++ b/addon/array/unzipWith.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/unzipWith'

--- a/addon/array/without.js
+++ b/addon/array/without.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/without'

--- a/addon/array/xor.js
+++ b/addon/array/xor.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/xor'

--- a/addon/array/zip.js
+++ b/addon/array/zip.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/zip'

--- a/addon/array/zipObject.js
+++ b/addon/array/zipObject.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/zipObject'

--- a/addon/array/zipWith.js
+++ b/addon/array/zipWith.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/zipWith'

--- a/addon/chain/chain.js
+++ b/addon/chain/chain.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/chain'

--- a/addon/chain/commit.js
+++ b/addon/chain/commit.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/commit'

--- a/addon/chain/concat.js
+++ b/addon/chain/concat.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/concat'

--- a/addon/chain/lodash.js
+++ b/addon/chain/lodash.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/lodash'

--- a/addon/chain/plant.js
+++ b/addon/chain/plant.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/plant'

--- a/addon/chain/reverse.js
+++ b/addon/chain/reverse.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reverse'

--- a/addon/chain/run.js
+++ b/addon/chain/run.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/value'

--- a/addon/chain/tap.js
+++ b/addon/chain/tap.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/tap'

--- a/addon/chain/thru.js
+++ b/addon/chain/thru.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/thru'

--- a/addon/chain/toJSON.js
+++ b/addon/chain/toJSON.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/toJSON'

--- a/addon/chain/toString.js
+++ b/addon/chain/toString.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/toString'

--- a/addon/chain/value.js
+++ b/addon/chain/value.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/value'

--- a/addon/chain/valueOf.js
+++ b/addon/chain/valueOf.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/valueOf'

--- a/addon/chain/wrapperChain.js
+++ b/addon/chain/wrapperChain.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/wrapperChain'

--- a/addon/chain/wrapperReverse.js
+++ b/addon/chain/wrapperReverse.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/wrapperReverse'

--- a/addon/chain/wrapperValue.js
+++ b/addon/chain/wrapperValue.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/wrapperValue'

--- a/addon/collection/all.js
+++ b/addon/collection/all.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/every'

--- a/addon/collection/any.js
+++ b/addon/collection/any.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/some'

--- a/addon/collection/at.js
+++ b/addon/collection/at.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/at'

--- a/addon/collection/collect.js
+++ b/addon/collection/collect.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/map'

--- a/addon/collection/contains.js
+++ b/addon/collection/contains.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/includes'

--- a/addon/collection/countBy.js
+++ b/addon/collection/countBy.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/countBy'

--- a/addon/collection/detect.js
+++ b/addon/collection/detect.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/find'

--- a/addon/collection/each.js
+++ b/addon/collection/each.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/each'

--- a/addon/collection/eachRight.js
+++ b/addon/collection/eachRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/eachRight'

--- a/addon/collection/every.js
+++ b/addon/collection/every.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/every'

--- a/addon/collection/filter.js
+++ b/addon/collection/filter.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/filter'

--- a/addon/collection/find.js
+++ b/addon/collection/find.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/find'

--- a/addon/collection/findLast.js
+++ b/addon/collection/findLast.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/findLast'

--- a/addon/collection/findWhere.js
+++ b/addon/collection/findWhere.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/find'

--- a/addon/collection/foldl.js
+++ b/addon/collection/foldl.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reduce'

--- a/addon/collection/foldr.js
+++ b/addon/collection/foldr.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reduceRight'

--- a/addon/collection/forEach.js
+++ b/addon/collection/forEach.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/forEach'

--- a/addon/collection/forRight.js
+++ b/addon/collection/forRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/forRight'

--- a/addon/collection/groupBy.js
+++ b/addon/collection/groupBy.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/groupBy'

--- a/addon/collection/include.js
+++ b/addon/collection/include.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/includes'

--- a/addon/collection/includes.js
+++ b/addon/collection/includes.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/includes'

--- a/addon/collection/indexBy.js
+++ b/addon/collection/indexBy.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/keyBy'

--- a/addon/collection/inject.js
+++ b/addon/collection/inject.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reduce'

--- a/addon/collection/invoke.js
+++ b/addon/collection/invoke.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/invoke'

--- a/addon/collection/map.js
+++ b/addon/collection/map.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/map'

--- a/addon/collection/max.js
+++ b/addon/collection/max.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/max'

--- a/addon/collection/min.js
+++ b/addon/collection/min.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/min'

--- a/addon/collection/partition.js
+++ b/addon/collection/partition.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/partition'

--- a/addon/collection/pluck.js
+++ b/addon/collection/pluck.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/map'

--- a/addon/collection/reduce.js
+++ b/addon/collection/reduce.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reduce'

--- a/addon/collection/reduceRight.js
+++ b/addon/collection/reduceRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reduceRight'

--- a/addon/collection/reject.js
+++ b/addon/collection/reject.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/reject'

--- a/addon/collection/sample.js
+++ b/addon/collection/sample.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sample'

--- a/addon/collection/select.js
+++ b/addon/collection/select.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/filter'

--- a/addon/collection/shuffle.js
+++ b/addon/collection/shuffle.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/shuffle'

--- a/addon/collection/size.js
+++ b/addon/collection/size.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/size'

--- a/addon/collection/some.js
+++ b/addon/collection/some.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/some'

--- a/addon/collection/sortBy.js
+++ b/addon/collection/sortBy.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sortBy'

--- a/addon/collection/sortByAll.js
+++ b/addon/collection/sortByAll.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sortBy'

--- a/addon/collection/sortByOrder.js
+++ b/addon/collection/sortByOrder.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/orderBy'

--- a/addon/collection/sum.js
+++ b/addon/collection/sum.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sum'

--- a/addon/collection/where.js
+++ b/addon/collection/where.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/filter'

--- a/addon/date/now.js
+++ b/addon/date/now.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/now'

--- a/addon/function/after.js
+++ b/addon/function/after.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/after'

--- a/addon/function/ary.js
+++ b/addon/function/ary.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/ary'

--- a/addon/function/backflow.js
+++ b/addon/function/backflow.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/flowRight'

--- a/addon/function/before.js
+++ b/addon/function/before.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/before'

--- a/addon/function/bind.js
+++ b/addon/function/bind.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/bind'

--- a/addon/function/bindAll.js
+++ b/addon/function/bindAll.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/bindAll'

--- a/addon/function/bindKey.js
+++ b/addon/function/bindKey.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/bindKey'

--- a/addon/function/compose.js
+++ b/addon/function/compose.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/flowRight'

--- a/addon/function/curry.js
+++ b/addon/function/curry.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/curry'

--- a/addon/function/curryRight.js
+++ b/addon/function/curryRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/curryRight'

--- a/addon/function/debounce.js
+++ b/addon/function/debounce.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/debounce'

--- a/addon/function/defer.js
+++ b/addon/function/defer.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/defer'

--- a/addon/function/delay.js
+++ b/addon/function/delay.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/delay'

--- a/addon/function/flow.js
+++ b/addon/function/flow.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/flow'

--- a/addon/function/flowRight.js
+++ b/addon/function/flowRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/flowRight'

--- a/addon/function/memoize.js
+++ b/addon/function/memoize.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/memoize'

--- a/addon/function/modArgs.js
+++ b/addon/function/modArgs.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/overArgs'

--- a/addon/function/negate.js
+++ b/addon/function/negate.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/negate'

--- a/addon/function/once.js
+++ b/addon/function/once.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/once'

--- a/addon/function/partial.js
+++ b/addon/function/partial.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/partial'

--- a/addon/function/partialRight.js
+++ b/addon/function/partialRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/partialRight'

--- a/addon/function/rearg.js
+++ b/addon/function/rearg.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/rearg'

--- a/addon/function/restParam.js
+++ b/addon/function/restParam.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/rest'

--- a/addon/function/spread.js
+++ b/addon/function/spread.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/spread'

--- a/addon/function/throttle.js
+++ b/addon/function/throttle.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/throttle'

--- a/addon/function/wrap.js
+++ b/addon/function/wrap.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/wrap'

--- a/addon/lang/clone.js
+++ b/addon/lang/clone.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/clone'

--- a/addon/lang/cloneDeep.js
+++ b/addon/lang/cloneDeep.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/cloneDeep'

--- a/addon/lang/eq.js
+++ b/addon/lang/eq.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/eq'

--- a/addon/lang/gt.js
+++ b/addon/lang/gt.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/gt'

--- a/addon/lang/gte.js
+++ b/addon/lang/gte.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/gte'

--- a/addon/lang/isArguments.js
+++ b/addon/lang/isArguments.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isArguments'

--- a/addon/lang/isArray.js
+++ b/addon/lang/isArray.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isArray'

--- a/addon/lang/isBoolean.js
+++ b/addon/lang/isBoolean.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isBoolean'

--- a/addon/lang/isDate.js
+++ b/addon/lang/isDate.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isDate'

--- a/addon/lang/isElement.js
+++ b/addon/lang/isElement.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isElement'

--- a/addon/lang/isEmpty.js
+++ b/addon/lang/isEmpty.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isEmpty'

--- a/addon/lang/isEqual.js
+++ b/addon/lang/isEqual.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isEqual'

--- a/addon/lang/isError.js
+++ b/addon/lang/isError.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isError'

--- a/addon/lang/isFinite.js
+++ b/addon/lang/isFinite.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isFinite'

--- a/addon/lang/isMatch.js
+++ b/addon/lang/isMatch.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isMatch'

--- a/addon/lang/isNaN.js
+++ b/addon/lang/isNaN.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isNaN'

--- a/addon/lang/isNative.js
+++ b/addon/lang/isNative.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isNative'

--- a/addon/lang/isNull.js
+++ b/addon/lang/isNull.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isNull'

--- a/addon/lang/isNumber.js
+++ b/addon/lang/isNumber.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isNumber'

--- a/addon/lang/isObject.js
+++ b/addon/lang/isObject.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isObject'

--- a/addon/lang/isPlainObject.js
+++ b/addon/lang/isPlainObject.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isPlainObject'

--- a/addon/lang/isRegExp.js
+++ b/addon/lang/isRegExp.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isRegExp'

--- a/addon/lang/isString.js
+++ b/addon/lang/isString.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isString'

--- a/addon/lang/isTypedArray.js
+++ b/addon/lang/isTypedArray.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isTypedArray'

--- a/addon/lang/isUndefined.js
+++ b/addon/lang/isUndefined.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isUndefined'

--- a/addon/lang/lt.js
+++ b/addon/lang/lt.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/lt'

--- a/addon/lang/lte.js
+++ b/addon/lang/lte.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/lte'

--- a/addon/lang/toArray.js
+++ b/addon/lang/toArray.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/toArray'

--- a/addon/lang/toPlainObject.js
+++ b/addon/lang/toPlainObject.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/toPlainObject'

--- a/addon/math/add.js
+++ b/addon/math/add.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/add'

--- a/addon/math/ceil.js
+++ b/addon/math/ceil.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/ceil'

--- a/addon/math/floor.js
+++ b/addon/math/floor.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/floor'

--- a/addon/math/max.js
+++ b/addon/math/max.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/max'

--- a/addon/math/min.js
+++ b/addon/math/min.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/min'

--- a/addon/math/round.js
+++ b/addon/math/round.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/round'

--- a/addon/math/sum.js
+++ b/addon/math/sum.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/sum'

--- a/addon/number/inRange.js
+++ b/addon/number/inRange.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/inRange'

--- a/addon/number/random.js
+++ b/addon/number/random.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/random'

--- a/addon/object/assign.js
+++ b/addon/object/assign.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/assign'

--- a/addon/object/create.js
+++ b/addon/object/create.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/create'

--- a/addon/object/defaults.js
+++ b/addon/object/defaults.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/defaults'

--- a/addon/object/defaultsDeep.js
+++ b/addon/object/defaultsDeep.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/defaultsDeep'

--- a/addon/object/extend.js
+++ b/addon/object/extend.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/extend'

--- a/addon/object/findKey.js
+++ b/addon/object/findKey.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/findKey'

--- a/addon/object/forIn.js
+++ b/addon/object/forIn.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/forIn'

--- a/addon/object/forInRight.js
+++ b/addon/object/forInRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/forInRight'

--- a/addon/object/forOwn.js
+++ b/addon/object/forOwn.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/forOwn'

--- a/addon/object/forOwnRight.js
+++ b/addon/object/forOwnRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/forOwnRight'

--- a/addon/object/functions.js
+++ b/addon/object/functions.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/functions'

--- a/addon/object/get.js
+++ b/addon/object/get.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/get'

--- a/addon/object/has.js
+++ b/addon/object/has.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/has'

--- a/addon/object/invert.js
+++ b/addon/object/invert.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/invert'

--- a/addon/object/keys.js
+++ b/addon/object/keys.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/keys'

--- a/addon/object/keysIn.js
+++ b/addon/object/keysIn.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/keysIn'

--- a/addon/object/mapKeys.js
+++ b/addon/object/mapKeys.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/mapKeys'

--- a/addon/object/mapValues.js
+++ b/addon/object/mapValues.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/mapValues'

--- a/addon/object/merge.js
+++ b/addon/object/merge.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/merge'

--- a/addon/object/methods.js
+++ b/addon/object/methods.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/functions'

--- a/addon/object/omit.js
+++ b/addon/object/omit.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/omit'

--- a/addon/object/pairs.js
+++ b/addon/object/pairs.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/toPairs'

--- a/addon/object/pick.js
+++ b/addon/object/pick.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/pick'

--- a/addon/object/result.js
+++ b/addon/object/result.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/result'

--- a/addon/object/set.js
+++ b/addon/object/set.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/set'

--- a/addon/object/transform.js
+++ b/addon/object/transform.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/transform'

--- a/addon/string/camelCase.js
+++ b/addon/string/camelCase.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/camelCase'

--- a/addon/string/capitalize.js
+++ b/addon/string/capitalize.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/capitalize'

--- a/addon/string/deburr.js
+++ b/addon/string/deburr.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/deburr'

--- a/addon/string/endsWith.js
+++ b/addon/string/endsWith.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/endsWith'

--- a/addon/string/escape.js
+++ b/addon/string/escape.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/escape'

--- a/addon/string/escapeRegExp.js
+++ b/addon/string/escapeRegExp.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/escapeRegExp'

--- a/addon/string/kebabCase.js
+++ b/addon/string/kebabCase.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/kebabCase'

--- a/addon/string/pad.js
+++ b/addon/string/pad.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/pad'

--- a/addon/string/padLeft.js
+++ b/addon/string/padLeft.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/padStart'

--- a/addon/string/padRight.js
+++ b/addon/string/padRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/padEnd'

--- a/addon/string/parseInt.js
+++ b/addon/string/parseInt.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/parseInt'

--- a/addon/string/repeat.js
+++ b/addon/string/repeat.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/repeat'

--- a/addon/string/snakeCase.js
+++ b/addon/string/snakeCase.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/snakeCase'

--- a/addon/string/startCase.js
+++ b/addon/string/startCase.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/startCase'

--- a/addon/string/startsWith.js
+++ b/addon/string/startsWith.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/startsWith'

--- a/addon/string/template.js
+++ b/addon/string/template.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/template'

--- a/addon/string/templateSettings.js
+++ b/addon/string/templateSettings.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/templateSettings'

--- a/addon/string/trim.js
+++ b/addon/string/trim.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/trim'

--- a/addon/string/trimLeft.js
+++ b/addon/string/trimLeft.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/trimStart'

--- a/addon/string/trimRight.js
+++ b/addon/string/trimRight.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/trimEnd'

--- a/addon/string/trunc.js
+++ b/addon/string/trunc.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/truncate'

--- a/addon/string/unescape.js
+++ b/addon/string/unescape.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/unescape'

--- a/addon/string/words.js
+++ b/addon/string/words.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/words'

--- a/addon/utility/attempt.js
+++ b/addon/utility/attempt.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/attempt'

--- a/addon/utility/callback.js
+++ b/addon/utility/callback.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/iteratee'

--- a/addon/utility/constant.js
+++ b/addon/utility/constant.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/constant'

--- a/addon/utility/identity.js
+++ b/addon/utility/identity.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/identity'

--- a/addon/utility/iteratee.js
+++ b/addon/utility/iteratee.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/iteratee'

--- a/addon/utility/matches.js
+++ b/addon/utility/matches.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/matches'

--- a/addon/utility/matchesProperty.js
+++ b/addon/utility/matchesProperty.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/matchesProperty'

--- a/addon/utility/method.js
+++ b/addon/utility/method.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/method'

--- a/addon/utility/methodOf.js
+++ b/addon/utility/methodOf.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/methodOf'

--- a/addon/utility/mixin.js
+++ b/addon/utility/mixin.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/mixin'

--- a/addon/utility/noop.js
+++ b/addon/utility/noop.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/noop'

--- a/addon/utility/property.js
+++ b/addon/utility/property.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/property'

--- a/addon/utility/propertyOf.js
+++ b/addon/utility/propertyOf.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/propertyOf'

--- a/addon/utility/range.js
+++ b/addon/utility/range.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/range'

--- a/addon/utility/times.js
+++ b/addon/utility/times.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/times'

--- a/addon/utility/uniqueId.js
+++ b/addon/utility/uniqueId.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/uniqueId'


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Maintaining import paths from `lodash` version 3.x which is used by `ember-lodash` to prevent build issues with addons using those import paths.
