### PR TITLE
Add missing lodash/lang/isFunction file and fix production/minified builds

### DIFF
--- a/addon/_defineProperty.js
+++ b/addon/_defineProperty.js
@@ -1,2 +1,2 @@
 // Overwriting file from lodash-es as it breaks production/minified builds
-export default Object.defineProperty;
+export default Object.defineProperty

--- a/addon/_defineProperty.js
+++ b/addon/_defineProperty.js
@@ -1,0 +1,2 @@
+// Overwriting file from lodash-es as it breaks production/minified builds
+export default Object.defineProperty;

--- a/addon/lang/isFunction.js
+++ b/addon/lang/isFunction.js
@@ -1,0 +1,1 @@
+export {default} from 'lodash/isFunction'


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Added** file to make `import isFunction from 'lodash/lang/isFunction'` work from legacy lodash 3 code.
