### PR TITLE
Removing _shouldCompileJS (not needed anymore)

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,6 @@
 
 module.exports = {
   name: 'lodash',
-
-  /**
-   * Workaround needed for 2.12+
-   * see: https://github.com/ember-redux/ember-redux/issues/105#issuecomment-288001558
-   * @returns {boolean} Set to true to force JS compile
-   * @private
-   */
-  _shouldCompileJS: function () {
-    return true
-  },
-
   included (parent) {
     this._super.included(parent)
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Removed shouldCompileJS workaround