### PR TITLE
Fix super binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 
 module.exports = {
   name: 'lodash',
-  included (parent) {
-    this._super.included(parent)
+  included () {
+    this._super.included.apply(this, arguments)
 
     this.import({
       development: 'vendor/lodash/lodash.js',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "^0.3.2",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-lodash-shim/issues/53

# CHANGELOG
* **Updated** super call inside of `included` hook of `index.js` to bind the context to `this`