### PR TITLE
Move ember-cli-htmlbars from a dependency to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli": "2.12.3",
     "ember-cli-chai": "0.4.3",
     "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.14.4",
@@ -58,8 +59,7 @@
     "utility"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.1.1"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "after": [


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [X] #major# - incompatible API change

Closes: https://agile-jira.ciena.com/browse/FROST-750

# CHANGELOG
* **Updated** `ember-cli-htmlbars` to be a devDependency